### PR TITLE
It seems like 0 can be a valid value for backoffLimit. 

### DIFF
--- a/kronjob/schema.json
+++ b/kronjob/schema.json
@@ -40,7 +40,7 @@
         "backoffLimit": {
           "$comment": "`args` in generated job specs.",
           "type": "integer",
-          "minimum": 1
+          "minimum": 0
         },
         "concurrencyPolicy": {
           "$comment": "`concurrencyPolicy` in generated cron job specs.",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='kronjob',
-    version='2.0.3',
+    version='2.0.4',
     description='Generate Kubernetes Job/CronJob specs without the boilerplate.',
     install_requires=[
         'kubernetes==10.0.1',


### PR DESCRIPTION
Backofflimit 3:  restart onfailure
    — same pod name, but restarts number kept going up with exponential backoff
   —  after backup limit reached, pod went into terminated state and disappeared

Backofflimit 3:  restart Never
    — makes new pod each time, making 4 pods total
    
Backofflimit 0:  restart Never
    — ran once, left pod in Error

Backofflimit 0:  restart onFailure
    — ran once, no pod in list

with 
```
apiVersion: batch/v1
kind: Job
metadata:
  name: nursa-test
  labels:
    app: nursa-app
spec:
  template:
    spec:
      containers:
        - name: myapp-container
          image: busybox
          command: ['sh', '-c', 'sleep 2 & exit 1']
      restartPolicy: OnFailure
  backoffLimit: 0
```