### PR TITLE
PLAT-5599 | Allow disabling of Cronjob templating

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='kronjob',
-    version='2.1.0',
+    version='3.0.0',
     description='Generate Kubernetes Job/CronJob specs without the boilerplate.',
     install_requires=[
         'kubernetes==10.0.1',

--- a/test/test_kronjob.py
+++ b/test/test_kronjob.py
@@ -189,3 +189,13 @@ def test_cronjob_properties():
     serialized_job = list(yaml.safe_load_all(kronjob.serialize_k8s(k8s_job)))[0]  # noqa
     for _, output_path, value in properties:
         assert eval('serialized_job{}'.format(output_path)) == value
+
+
+def test_cronjob_disabled():
+    abstract_jobs = {
+        'image': 'example.com/base',
+        'schedule': '* * * * *',
+        'jobs': [{'name': 'test'}]
+    }
+    with pytest.raises(Exception):
+        kronjob.build_k8s_objects(abstract_jobs, disable_cronjobs=True)


### PR DESCRIPTION
Adds a new CLI flag `--disable-cronjobs` that will disable Cronjob templating. If this flag is set, and a kronjob template with schedule not equal to `once` is processed, kronjob will throw an error and exit with failure.

### Rollout plan
After announcing this change to PDE, we can add this new flag to Ship and Spinnaker scripts to completely disable Cronjob support. If we need to roll back, we just have to remove the flag from the CI scripts

### Alternatives considered
**Skip over Cronjobs by outputting a blank manifest instead of throwing an error**
I want to make sure that it is very clear to engineers that this functionality is no longer supported by causing builds to fail. If we simply skip over cronjob templates, job deployments would still appear successful and it would be too easy to miss.

**Validate kronjob templates before running kronjob**
We could instead create a new build step that validates all kronjob files, greps for `schedule` and ensures that no cron expressions are used. However, kronjob templates support a number of different configurations for jobs/cronjobs. Modifying kronjob directly seems like the most straightforward way to catch all possible Cronjobs.